### PR TITLE
add an option to show congregation names in shifts/calendars/emails

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -58,3 +58,4 @@ react-template-helper
 jquery
 fourseven:scss@4.10.0
 lookback:emails
+react-meteor-data

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -124,6 +124,7 @@ raix:eventemitter@0.1.3
 random@1.2.0
 rate-limit@1.0.9
 react-fast-refresh@0.2.2
+react-meteor-data@2.5.1
 react-template-helper@0.2.12
 reactive-dict@1.3.0
 reactive-var@1.0.11
@@ -146,6 +147,7 @@ templating-runtime@1.5.0
 templating-tools@1.2.0
 tmeasday:check-npm-versions@0.3.2
 tracker@1.2.0
+typescript@4.4.1
 ui@1.0.13
 underscore@1.0.10
 url@1.3.2

--- a/both/methods/project/project.coffee
+++ b/both/methods/project/project.coffee
@@ -5,8 +5,9 @@ Meteor.methods
 	updateProject: (projectId, field, value) ->
 		if Meteor.isServer
 			check { userId: Meteor.userId(), projectId: projectId }, isAdmin
-
-		if field == 'vesselModule' && Roles.userIsInRole Meteor.userId(), 'support', Roles.GLOBAL_GROUP
+		if field == 'showCongregationName'
+			Projects.update projectId, $set: showCongregationName: value
+		else if field == 'vesselModule' && Roles.userIsInRole Meteor.userId(), 'support', Roles.GLOBAL_GROUP
 			Projects.update projectId, $set: vesselModule: value
 		else if field == 'harbors' || value.trim() != '' || field.indexOf('news') > -1
 			set = {}

--- a/client/config/globals.coffee
+++ b/client/config/globals.coffee
@@ -1,4 +1,5 @@
 @UserStatistics = new Mongo.Collection 'userStatistics'
+@UserCongregations = new Mongo.Collection 'userCongregations'
 
 @handleError = (e) -> if e?
 	if e.error == 'validation-error'

--- a/client/views/common/shift/shift.tpl.jade
+++ b/client/views/common/shift/shift.tpl.jade
@@ -50,19 +50,19 @@ with getShift
                   .shift-team-participants
                     each sortUsers team.participants
                       div
-                        +React component=TeamMemberName member=this applyStyle=isMeShiftScheduler
+                        +React component=TeamMemberName member=this applyStyle=isMeShiftScheduler showCongregationName=true
                 if team.pending
                   if isProjectShiftScheduler
                     .shift-team-pendings
                       each sortUsers team.pending
                         span
-                          +React component=TeamMemberName member=this applyStyle=isMeShiftScheduler
+                          +React component=TeamMemberName member=this applyStyle=isMeShiftScheduler showCongregationName=true
                         br
                   else if directScheduling
                     .shift-team-pendings
                       each sortUsers team.pending
                         span
-                          +React component=TeamMemberName member=this applyStyle=isMeShiftScheduler
+                          +React component=TeamMemberName member=this applyStyle=isMeShiftScheduler showCongregationName=true
                         br
                   else if team.participants
                     .shift-team-information

--- a/client/views/pages/settings/settings.coffee
+++ b/client/views/pages/settings/settings.coffee
@@ -69,6 +69,8 @@ Template.settings.events
 
 	'change #projectEmail': (e) -> Meteor.call 'updateProject', @_id, 'email', e.target.value, handleError
 
+	'change #showCongregationName': (e) -> Meteor.call 'updateProject', @_id, 'showCongregationName', e.target.checked
+
 	'click .changeVesselModule': (e) -> Meteor.call 'updateProject', FlowRouter.getParam('projectId'), 'vesselModule', ($(e.target).attr('value') == 'true'), handleError
 
 	'change #country': (e) -> Meteor.call 'updateProject', @_id, 'country', e.target.value, handleError

--- a/client/views/pages/settings/settings.tpl.jade
+++ b/client/views/pages/settings/settings.tpl.jade
@@ -30,6 +30,11 @@ if queryParam 'editTeamPicture'
 									.col-sm-10.col-lg-8
 										input#projectEmail.form-control(type='email' placeholder='{{_ "settings.main.email.placeholder"}}' value='{{email}}')
 										span.help-block {{_ 'settings.main.email.helpText'}}
+								.form-group
+									label.col-sm-2.col-sm-2.col-lg-4.control-label {{_ 'settings.main.showCongregationName.text'}}
+									.col-sm-10.col-lg-8
+										input#showCongregationName.form-control(type='checkbox' checked='{{showCongregationName}}')
+										span.help-block {{_ 'settings.main.showCongregationName.helpText'}}
 								if isSupport
 									.form-group
 										label.col-sm-2.col-sm-2.col-lg-4.control-label Vessel project

--- a/imports/i18n/en-GB/pages.js
+++ b/imports/i18n/en-GB/pages.js
@@ -145,6 +145,10 @@ const pages = {
         placeholder: 'Project email address',
         helpText: 'In emails like shift confirmations and team leader updates, this address will be set as the Reply-To address, so that if the recipients answer these emails, the reply will normally be sent to the inbox of this address if the recipient\'s email program is behaving correctly. Furthermore, this address will be notified (e.g. on short-term participation cancellations).'
       },
+      showCongregationName: {
+        text: 'Congregation',
+        helpText: 'In some situations, where multiple congregations participate in a project, it is desirable to add the congregation name to the publisher. If this is wanted, please check the box.'
+      },
       language: {
         text: 'Language',
         helpText: 'If the system notifies the address listed above about changes, it will send the mails in the language you specify here.'

--- a/imports/ui/team/TeamMember.jsx
+++ b/imports/ui/team/TeamMember.jsx
@@ -54,10 +54,9 @@ export default class TeamMember extends Component {
         <i className='fa fa-phone fa-fw' />
       </a>
     ) : ''
-
     return (
       <div>
-        <TeamMemberName member={member} applyStyle={this.props.showStats} />
+        <TeamMemberName member={member} applyStyle={this.props.showStats} showCongregationName={!this.props.showStats}/>
         <TeamMemberStats userId={member._id} showStats={this.props.showStats} />
 
         <div className='float-right'>

--- a/imports/ui/team/TeamMemberName.jsx
+++ b/imports/ui/team/TeamMemberName.jsx
@@ -1,22 +1,33 @@
-import React, { Component } from 'react'
+import React from 'react'
+import { useTracker } from 'meteor/react-meteor-data'
+import { Meteor } from 'meteor/meteor'
 
-export default class TeamMemberName extends Component {
-  render () {
-    const member = this.props.member
-    let styledName = member.name
-
-    if (member.thisTeamleader) {
-      styledName = <u>{styledName}</u>
+export default ({ member, applyStyle, showCongregationName }) => {
+  const congregation = useTracker(() => {
+    if (!showCongregationName) {
+      return
     }
+    const projectId = FlowRouter.getParam('projectId')
+    Meteor.subscribe('userCongregation', projectId, member._id)
+    const userCongregation = UserCongregations.findOne(member._id)
+    return userCongregation && userCongregation.congregation
+  }, [member, showCongregationName])
 
-    if (this.props.applyStyle) {
-      if (member.teamleader) {
-        styledName = <b>{styledName}</b>
-      } else if (member.substituteTeamleader) {
-        styledName = <i>{styledName}</i>
+  const styledName = member.name + (congregation ? ` (${congregation})` : '')
+
+  if (member.thisTeamleader) {
+    return <u>{styledName}</u>
+  }
+
+  if (applyStyle) {
+    if (member.teamleader) {
+      return <b>{styledName}</b>
+    } else {
+      if (member.substituteTeamleader) {
+        return <i>{styledName}</i>
       }
     }
-
-    return styledName
   }
+
+  return styledName
 }

--- a/server/methods/mail/sendConfirmation.coffee
+++ b/server/methods/mail/sendConfirmation.coffee
@@ -5,7 +5,7 @@ Meteor.methods
 
 	sendConfirmation: (shiftId, teamId, userId) ->
 		shift = Shifts.findOne shiftId
-		project = Projects.findOne shift.projectId, fields: name: 1, email: 1
+		project = Projects.findOne shift.projectId, fields: name: 1, email: 1, showCongregationName: 1
 		user = Meteor.users.findOne userId, fields: profile: 1
 
 		if user? and shift?
@@ -18,6 +18,11 @@ Meteor.methods
 			shiftData.teams = []
 
 			for team in shift.teams when team.participants.length > 0
+				if project.showCongregationName
+					for participant in team.participants
+						user = Meteor.users.findOne participant._id, fields: profile: 1
+						if user.profile.congregation
+							participant.name = participant.name + ' (' + user.profile.congregation + ')'
 				shiftData.teams.push team
 
 			localTranslate = i18next.getFixedT(user.profile.language)

--- a/server/methods/mail/sendTeamUpdate.coffee
+++ b/server/methods/mail/sendTeamUpdate.coffee
@@ -5,7 +5,7 @@ Meteor.methods
 
 	sendTeamUpdate: (shiftId, teamId, type) ->
 		shift = Shifts.findOne shiftId
-		project = Projects.findOne shift.projectId, fields: name: 1, email: 1
+		project = Projects.findOne shift.projectId, fields: name: 1, email: 1, showCongregationName: 1
 
 		check { userId: Meteor.userId(), projectId: shift.projectId }, isMember
 		# fails sometimes because ? let's see what the logging beneath reveals
@@ -17,6 +17,11 @@ Meteor.methods
 			shiftData.teams = []
 
 		for team in shift.teams when team._id == teamId
+			if project.showCongregationName
+				for participant in team.participants
+					user = Meteor.users.findOne participant._id, fields: profile: 1
+					if user.profile.congregation
+						participant.name = participant.name + ' (' + user.profile.congregation + ')'
 			shiftData.teams[0] = team
 
 			for participant in team.participants when participant.informed

--- a/server/publish/userCongregation.js
+++ b/server/publish/userCongregation.js
@@ -1,0 +1,24 @@
+import { Meteor } from 'meteor/meteor'
+import { Roles } from 'meteor/alanning:roles'
+import Permissions from '../../imports/framework/Constants/Permissions'
+
+Meteor.publish('userCongregation', function (projectId, userId) {
+  if (
+    projectId &&
+    typeof projectId === 'string' &&
+    Roles.userIsInRole(this.userId, Permissions.member, projectId)
+  ) {
+    const project = Projects.findOne(
+      projectId,
+      { fields: { showCongregationName: 1 } }
+    )
+    if (project.showCongregationName) {
+      const user = Meteor.users.findOne(
+        userId,
+        { fields: { profile: 1 } }
+      )
+      this.added('userCongregations', userId, { congregation: user.profile.congregation })
+    }
+  }
+  this.ready()
+})


### PR DESCRIPTION
Added feature according to my own feature request ☺
Projects have now an option to add the congregation names to publisher names. This can be useful cases where multiple congregations participate in a project.
